### PR TITLE
Split incognito mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,5 +33,6 @@
     "html/*"
   ],
   "icons": { "16": "img/icon-16.png", "128": "img/icon-128.png" },
+  "incognito": "split",
   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js https://d24n15hnbwhuhn.cloudfront.net/libs/amplitude-3.0.1-min.gz.js 'unsafe-eval'; object-src 'self'"
 }


### PR DESCRIPTION
If I login in different accounts in the main Chrome window and in an incognito window, this extension confuses two, and shows stories from one in the other.

Split-mode should solve this issue: https://developer.chrome.com/extensions/manifest/incognito

Note: I've made this change directly in the GitHub web interface, I haven't tested it.