### PR TITLE
Issue #134 fix

### DIFF
--- a/utils/Story.js
+++ b/utils/Story.js
@@ -107,15 +107,15 @@ class Story extends Component {
   }
   
   hasReelMentions() {
-    return this.state.currentStoryItem.reel_mentions.length > 0;
+    return this.state.currentStoryItem.reel_mentions && this.state.currentStoryItem.reel_mentions.length > 0;
   }
   
   hasHashtags() {
-    return this.state.currentStoryItem.story_hashtags.length > 0;
+    return this.state.currentStoryItem.story_hashtags && this.state.currentStoryItem.story_hashtags.length > 0;
   }
   
   hasLocations() {
-    return this.state.currentStoryItem.story_locations.length > 0;
+    return this.state.currentStoryItem.story_locations && this.state.currentStoryItem.story_locations.length > 0;
   }
   
   hasStoryTags() {


### PR DESCRIPTION
Added check for the existence of a key in the map. As far as I understand, Instagram Api now does not return the fields reel_mentions, story_hashtags, story_locations in the history response, when these arrays are empty. But I'm not sure that this always happens.
#134 